### PR TITLE
Update default recipe to proxy to installation recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,4 +4,4 @@
 #
 # Copyright (c) 2016 Sebastian Boschert, All Rights Reserved.
 
-include_recipe 'docker_compose::default'
+include_recipe 'docker_compose::installation'


### PR DESCRIPTION
The documentation suggests that the `default` recipe is a proxy for the `installation` recipe. Upon inspecting the source, I found that the `default` recipe actually proxied to itself. I'm not sure how Chef reconciles that particular issue, but it appears that when using the `docker_compose::default` recipe it simply does nothing.

This change updates the `default` recipe to actually proxy, as per the documentation.