### PR TITLE
attributes/default.rb: bump default['docker_compose']['release'] to 1.21.2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
-default['docker_compose']['release'] = '1.8.0'
+default['docker_compose']['release'] = '1.21.2'
 default['docker_compose']['command_path'] = '/usr/local/bin/docker-compose'


### PR DESCRIPTION
This changes the default of the installed docker compose binary to something later.