### PR TITLE
Resolve missing local properties

### DIFF
--- a/resources/application.rb
+++ b/resources/application.rb
@@ -28,6 +28,8 @@ def get_down_params
 end
 
 action :up do
+  project_name = new_resource.project_name || current_resource.project_name
+
   execute "running docker-compose up for project #{project_name}" do
     command "docker-compose #{get_compose_params} up #{get_up_params}"
     user 'root'
@@ -36,6 +38,8 @@ action :up do
 end
 
 action :create do
+  project_name = new_resource.project_name || current_resource.project_name
+
   execute "running docker-compose create for project #{project_name}" do
     command "docker-compose #{get_compose_params} create #{get_up_params}"
     user 'root'
@@ -44,6 +48,8 @@ action :create do
 end
 
 action :down do
+  project_name = new_resource.project_name || current_resource.project_name
+
   execute "running docker-compose down for project #{project_name}" do
     command "docker-compose #{get_compose_params} down  #{get_down_params}"
     user 'root'

--- a/resources/application.rb
+++ b/resources/application.rb
@@ -32,6 +32,7 @@ action :up do
 
   execute "running docker-compose up for project #{project_name}" do
     command "docker-compose #{get_compose_params} up #{get_up_params}"
+    environment('PATH' => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin')
     user 'root'
     group 'root'
   end
@@ -42,6 +43,7 @@ action :create do
 
   execute "running docker-compose create for project #{project_name}" do
     command "docker-compose #{get_compose_params} create #{get_up_params}"
+    environment('PATH' => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin')
     user 'root'
     group 'root'
   end
@@ -52,6 +54,7 @@ action :down do
 
   execute "running docker-compose down for project #{project_name}" do
     command "docker-compose #{get_compose_params} down  #{get_down_params}"
+    environment('PATH' => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin')
     user 'root'
     group 'root'
   end

--- a/resources/application.rb
+++ b/resources/application.rb
@@ -29,10 +29,12 @@ end
 
 action :up do
   project_name = new_resource.project_name || current_resource.project_name
+  compose_files = new_resource.compose_files || current_resource.compose_files
 
   execute "running docker-compose up for project #{project_name}" do
     command "docker-compose #{get_compose_params} up #{get_up_params}"
     environment('PATH' => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin')
+    only_if "[ $(docker-compose -f #{compose_files.join(' -f ')} ps -q | wc -l) -eq 0 ]"
     user 'root'
     group 'root'
   end
@@ -51,10 +53,12 @@ end
 
 action :down do
   project_name = new_resource.project_name || current_resource.project_name
+  compose_files = new_resource.compose_files || current_resource.compose_files
 
   execute "running docker-compose down for project #{project_name}" do
     command "docker-compose #{get_compose_params} down  #{get_down_params}"
     environment('PATH' => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin')
+    not_if "[ $(docker-compose -f #{compose_files.join(' -f ')} ps -q | wc -l) -eq 0 ]"
     user 'root'
     group 'root'
   end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,6 +9,11 @@ require 'spec_helper'
 describe 'docker_compose::default' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
+      # This doesn't help if the default attributes are changed. Maybe this should override the defaults
+      #   with new "defaults" just for the test. Then the stubbed command path and version would match.
+      #   That's just a different level of hard-coding, though.
+      stub_command("/usr/local/bin/docker-compose --version | grep 1.21.2").and_return(true)
+
       runner = ChefSpec::ServerRunner.new
       runner.converge(described_recipe)
     end


### PR DESCRIPTION
This should resolve issue #19 .
Additionally, it fixes rspec tests that may have become broken since newer versions of Chef, Chef DK, and chef-rspec.
It also sets a default path, specifically so that it can function on Centos, where (at least in kitchen testing) docker-compose's location isn't in the default path.
Additionally, it fixes an issue where running a cookbook that contains `docker_compose_application` with the `up` action would run, regardless of if it was already running.