### PR TITLE
Add restarts and allow for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Docker.
 ## Usage
 
 Place a dependency on the docker-compose cookbook in your cookbook's
-metadata.rb 
+metadata.rb
 
 ```ruby
 depends 'docker_compose', '~> 0.0'
@@ -81,7 +81,7 @@ via the `node['docker_compose']['command_path']` attribute.
 
 
 ## Resources
- 
+
 ### docker_compose_application
 
 The `docker_compose_application` provisions a Docker application (that usually
@@ -106,25 +106,28 @@ end
 - `compose_files` - The list of Compose files that makes up the Docker Compose
  application. The specified file names are passed to the `docker-compose`
  command in the order in which they appear in the list.
- 
+
 - `services` - The list of services to start or stop.
  Defaults to all services that are specified in the Compose files.
- 
+
 - `remove_orphans` - Remove containers for services not defined in the
  Compose file.
- 
+
 #### Actions
 
 - `:up` - Create and start containers.
-  Equivalent to calling `docker-compose up` with the Compose files 
-  that were specified using the `compose_files` parameter.
- 
-- `:down` - Stop and remove containers, networks, images, and volumes.
-  Equivalent to calling `docker-compose down` with the Compose files 
+  Equivalent to calling `docker-compose up -d --build` with the Compose files
   that were specified using the `compose_files` parameter.
 
+- `:down` - Stop and remove containers and networks.
+  Equivalent to calling `docker-compose down` with the Compose files
+  that were specified using the `compose_files` parameter.
+
+- `:restart` - Calls down and up actions.
+  Useful for notications from changes to Dockerfiles and Compose files.
+
 - `:create` - Create containers for a service.
-  Equivalent to calling `docker-compose create` with the Compose files 
+  Equivalent to calling `docker-compose create` with the Compose files
   that were specified using the `compose_files` parameter.
 
 

--- a/resources/application.rb
+++ b/resources/application.rb
@@ -17,7 +17,10 @@ def get_compose_params
 end
 
 def get_up_params
-  '-d' +
+  # '--build' is ignored if there is nothing in the compose file that uses it and
+  #   will result in no image changes if nothing in the Dockerfile's layers have
+  #   changed
+  '-d --build' +
     (remove_orphans ? ' --remove-orphans' : '') +
     (services.nil? ? '' : ' ' + services.join(' '))
 end
@@ -49,4 +52,9 @@ action :down do
     user 'root'
     group 'root'
   end
+end
+
+action :restart do
+  action_down
+  action_up
 end

--- a/test/cookbooks/docker_compose_test/files/default/Dockerfile.nginx_custom
+++ b/test/cookbooks/docker_compose_test/files/default/Dockerfile.nginx_custom
@@ -1,0 +1,3 @@
+FROM nginx
+
+COPY Dockerfile /

--- a/test/cookbooks/docker_compose_test/files/default/docker-compose_build_1.yml
+++ b/test/cookbooks/docker_compose_test/files/default/docker-compose_build_1.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  web_server:
+    image: nginx
+    ports:
+      - "8991:80"

--- a/test/cookbooks/docker_compose_test/files/default/docker-compose_build_2.yml
+++ b/test/cookbooks/docker_compose_test/files/default/docker-compose_build_2.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  web_server:
+    build: ./nginx_custom
+    ports:
+      - "8991:80"

--- a/test/cookbooks/docker_compose_test/recipes/application_build.rb
+++ b/test/cookbooks/docker_compose_test/recipes/application_build.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: docker_compose_test
+# Recipe:: project_up
+#
+# Copyright (c) 2016 Sebastian Boschert, All Rights Reserved.
+
+cookbook_file 'compose_build_1.yml' do
+  action :create
+  path '/etc/docker-compose/docker-compose_build.yml'
+  source 'docker-compose_build_1.yml'
+  owner 'root'
+  group 'root'
+  mode 0640
+  notifies :up, 'docker_compose_application[builtapp]', :immediate
+end
+
+docker_compose_application 'builtapp' do
+  action :up
+  compose_files [ '/etc/docker-compose/docker-compose_build.yml' ]
+end
+
+directory '/etc/docker-compose/nginx_custom' do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
+end
+
+cookbook_file '/etc/docker-compose/nginx_custom/Dockerfile' do
+  source 'Dockerfile.nginx_custom'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
+end
+
+cookbook_file 'compose_build_2.yml' do
+  path '/etc/docker-compose/docker-compose_build.yml'
+  source 'docker-compose_build_2.yml'
+  owner 'root'
+  group 'root'
+  mode 0640
+  notifies :restart, 'docker_compose_application[builtapp]', :immediate
+end

--- a/test/cookbooks/docker_compose_test/recipes/application_up_remove_orphans.rb
+++ b/test/cookbooks/docker_compose_test/recipes/application_up_remove_orphans.rb
@@ -10,7 +10,7 @@ cookbook_file '/etc/docker-compose/docker-compose_remove_orphans_1.yml' do
   owner 'root'
   group 'root'
   mode 0640
-  notifies :up, 'docker_compose_application[nginx]', :delayed
+  notifies :up, 'docker_compose_application[removeorphans1]', :delayed
 end
 
 cookbook_file '/etc/docker-compose/docker-compose_remove_orphans_2.yml' do
@@ -19,7 +19,7 @@ cookbook_file '/etc/docker-compose/docker-compose_remove_orphans_2.yml' do
   owner 'root'
   group 'root'
   mode 0640
-  notifies :up, 'docker_compose_application[nginx]', :delayed
+  notifies :up, 'docker_compose_application[removeorphans2]', :delayed
 end
 
 docker_compose_application 'removeorphans1' do

--- a/test/cookbooks/docker_compose_test/recipes/default.rb
+++ b/test/cookbooks/docker_compose_test/recipes/default.rb
@@ -7,3 +7,4 @@
 include_recipe 'docker_compose_test::installation'
 include_recipe 'docker_compose_test::application_up'
 include_recipe 'docker_compose_test::application_up_remove_orphans'
+include_recipe 'docker_compose_test::application_build'


### PR DESCRIPTION
Adds restart action and `--build` parameter to `up` action.  `--build` is ignored for Compose files that don't explicitly ask for it.

In addition to adding the new action to the documentation, I cleaned up the language for the `down` action, which incorrectly suggested that `docker-compose down` removes images and volumes. It will remove volumes with the `-v` option and images have to be explicitly removed with `docker image` sub-commands.

Testing will pass more successfully on this PR if #20 is merged first.