### PR TITLE
Provide execute permissions to others

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description 'Installs docker_compose and provides the docker_compose_applic
 chef_version '>= 12'
 source_url 'https://github.com/sboschert/chef-cookbook-docker_compose'
 issues_url 'https://github.com/sboschert/chef-cookbook-docker_compose/issues'
-version '0.1.2'
+version '0.1.3'
 
 supports 'debian'
 supports 'ubuntu'

--- a/recipes/installation.rb
+++ b/recipes/installation.rb
@@ -27,7 +27,7 @@ end
 
 execute 'install docker-compose' do
   action :run
-  command "curl -sSL #{install_url} > #{command_path} && chmod +x #{command_path}"
+  command "curl -sSL #{install_url} > #{command_path} && chmod 755 #{command_path}"
   user 'root'
   group 'docker'
   umask '0027'


### PR DESCRIPTION
Other users in the system doesn't have execute permissions for **docker-compose**.